### PR TITLE
Require a minimum of Go 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can download prebuilt binaries from the GitHub releases or from our [downloa
 
 ## Development
 
-Make sure you have a working Go environment, for further reference or a guide take a look at the [install instructions](http://golang.org/doc/install.html). This project requires Go >= v1.12. For the frontend it's also required to have [NodeJS](https://nodejs.org/en/download/package-manager/) and [Yarn](https://yarnpkg.com/lang/en/docs/install/) installed.
+Make sure you have a working Go environment, for further reference or a guide take a look at the [install instructions](http://golang.org/doc/install.html). This project requires Go >= v1.13. For the frontend it's also required to have [NodeJS](https://nodejs.org/en/download/package-manager/) and [Yarn](https://yarnpkg.com/lang/en/docs/install/) installed.
 
 ```console
 git clone https://github.com/owncloud/ocis-graph.git

--- a/docs/content/building.md
+++ b/docs/content/building.md
@@ -5,7 +5,7 @@ anchor: "building"
 weight: 30
 ---
 
-As this project is built with Go, so you need to install that first. The installation of Go is out of the scope of this document, please follow the official documentation for [Go](https://golang.org/doc/install), to build this project you have to install Go >= v1.12. After the installation of the required tools you need to get the sources:
+As this project is built with Go, so you need to install that first. The installation of Go is out of the scope of this document, please follow the official documentation for [Go](https://golang.org/doc/install), to build this project you have to install Go >= v1.13. After the installation of the required tools you need to get the sources:
 
 {{< highlight txt >}}
 git clone https://github.com/owncloud/ocis-graph.git


### PR DESCRIPTION
Some dependencies of the ocis extensions require crypto/ed25519 which
doesn't seem to be available in Go 1.12.

